### PR TITLE
Improved Parser

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -84,9 +84,11 @@ struct sloth_program* parse(char* filepath){
     len = strlen(line);
     //Make sure the line is okay
     if(line[0] == -1){
+      free(line);
       break;
     }
     if(len == 0){
+      free(line);
       continue;
     }
     

--- a/parser.c
+++ b/parser.c
@@ -32,13 +32,13 @@ struct sloth_program* parse(char* filepath){
   int numCodes = progLen(sFile);
   ubyte* byteCode = malloc(sizeof(char) * numCodes);
 
-	char c = '\0';
+  char c = '\0';
   int count = 0;
   char cmd[6];
   size_t codeNum = 0;
   unsigned char currentCode = 0;
 
-	while(c != -1){
+  while(c != -1){
     c = fgetc(sFile);
     if(c == '#'){
       while(c != '\n'){
@@ -47,7 +47,7 @@ struct sloth_program* parse(char* filepath){
       fseek(sFile, -1, SEEK_CUR);
     }else if(c == ' ' || c == '\n' || c == -1){
       cmd[count] = '\0';
-			if(strcmp(cmd, "sloth") == 0){
+      if(strcmp(cmd, "sloth") == 0){
         currentCode++;
       }else if(strcmp(cmd, "and") == 0){
         byteCode[codeNum] = currentCode;
@@ -66,11 +66,11 @@ struct sloth_program* parse(char* filepath){
         currentCode = 0;
       }
       count = 0;
-		}else{
-			cmd[count] = c;
+    }else{
+      cmd[count] = c;
       count++;
-		}
-	}
+    }
+  }
   // for(int i = 0; i < numCodes; i++){
   //   printf("%x\n", byteCode[i]);
   // }

--- a/parser.c
+++ b/parser.c
@@ -22,7 +22,8 @@ void freeProgram(struct sloth_program* P){
 }
 
 //Read a line delimited by \n from file
-//Result is null terminated
+//Allocates a null terminated buffer to hold the line.
+//Caller is responsible for freeing it.
 //If the line is blank result will be empty
 //If end of file is reached while reading a line, the last non null character
 //in the buffer will be -1.
@@ -48,6 +49,7 @@ char *readline(FILE *file){
     line[currentChar] = c;
     currentChar++;
   }
+  //If at end of file put EOF in buffer
   if(c == -1){
     line[currentChar] = -1;
     currentChar++;
@@ -70,7 +72,7 @@ struct sloth_program* parse(char* filepath){
   ubyte* byteCode = malloc(sizeof(char) * numCodes);
 
   char c = '\0';
-  size_t count = 0;
+  size_t count = 0;//Current position in line
   char *line = 0x0;
   size_t len = 0;
   size_t codeNum = 0;
@@ -97,11 +99,7 @@ struct sloth_program* parse(char* filepath){
       if(c == '#'){
         break;
       }
-      if(isspace(c)){
-	count++;
-	c = line[count];
-	continue;
-      }
+      //Check keywords
       if(strncmp("slothy", line + count, 6) == 0){
 	byteCode[codeNum] = 0x1;
 	codeNum++;
@@ -119,6 +117,7 @@ struct sloth_program* parse(char* filepath){
 	codeNum++;
 	count += 3;
       }else{
+	//Ignore any other characters
 	count++;
       }
       c = line[count];

--- a/parser.c
+++ b/parser.c
@@ -20,6 +20,39 @@ void freeProgram(struct sloth_program* P){
   free(P);
 }
 
+//Read a line delimited by \n from file
+//Result is null terminated
+//If the line is blank result will be empty
+//If end of file is reached while reading a line, the last non null character
+//in the buffer will be -1. Or, if readline is called on a file that has been
+//read completely to the end, the buffer will be empty.
+char *readline(FILE *file){
+  //Default length of 100 characters - feel free to use a different value
+  const size_t default_len = 100;
+  char *line = malloc(sizeof(char) * default_len);
+  size_t len = default_len;
+  size_t currentChar = 0;
+  char c = '\0';
+
+  while(c != -1){
+    c = fgetc(file);
+    //Get more memory to hold the line if needed
+    if(currentChar == len){
+      len *= 2;
+      line = realloc(line, len);
+    }
+    if(c == '\n'){
+      break;
+    }
+
+    line[currentChar] = c;
+    currentChar++;
+  }
+
+  line[currentChar] = '\0';
+  return line;
+}
+
 struct sloth_program* parse(char* filepath){
   FILE* sFile;
 


### PR DESCRIPTION
I fixed everything in #6. I ended up rewriting a lot of it, but it should be a good bit more robust. For example, it doesn't even need whitespace inside of a line to separate things.
`slothyslothsloth`
and
`slothy sloth sloth`
both work now.
Anything that's not 'slothy', 'sloth', 'and', or 'nap' gets completely ignored.