### PR TITLE
Fix prompt in input instruction

### DIFF
--- a/Examples/Echo.sloth
+++ b/Examples/Echo.sloth
@@ -1,0 +1,6 @@
+#Copies its input to stdout
+sloth sloth sloth sloth sloth sloth sloth and sloth sloth #Read character
+sloth sloth sloth sloth sloth sloth sloth sloth and sloth #Write it out
+slothy sloth #push 1
+sloth sloth sloth sloth sloth sloth sloth sloth sloth and #Start again
+nap

--- a/Examples/Gamut.sloth
+++ b/Examples/Gamut.sloth
@@ -1,0 +1,54 @@
+#A sloth program that generates all the bytecode instructions used by the vm
+#Goto
+slothy sloth
+sloth sloth sloth sloth sloth sloth sloth sloth sloth and sloth sloth
+#Arithmetic
+slothy sloth sloth
+slothy sloth sloth
+sloth sloth #add
+slothy sloth sloth
+slothy sloth sloth
+sloth sloth sloth #subtract
+slothy sloth sloth
+slothy sloth sloth
+sloth sloth sloth sloth #multiply
+slothy sloth sloth
+slothy sloth sloth
+sloth sloth sloth sloth sloth #divide
+
+#Comparisons
+# ==
+slothy sloth sloth
+slothy sloth sloth
+sloth sloth sloth sloth sloth sloth and sloth #true (1)
+# !=
+slothy sloth sloth
+slothy sloth sloth
+sloth sloth sloth sloth sloth sloth and sloth sloth #false (0)
+# <
+slothy sloth sloth
+slothy sloth sloth
+sloth sloth sloth sloth sloth sloth and sloth sloth sloth #false
+# <=
+slothy sloth sloth
+slothy sloth sloth
+sloth sloth sloth sloth sloth sloth and sloth sloth sloth sloth #true
+# >
+slothy sloth sloth
+slothy sloth sloth
+sloth sloth sloth sloth sloth sloth and sloth sloth sloth sloth sloth #false
+# >=
+slothy sloth sloth
+slothy sloth sloth
+sloth sloth sloth sloth sloth sloth and sloth sloth sloth sloth sloth sloth #true
+
+#I/O
+sloth sloth sloth sloth sloth sloth sloth and sloth sloth
+sloth sloth sloth sloth sloth sloth sloth and sloth
+sloth sloth sloth sloth sloth sloth sloth sloth and sloth
+sloth sloth sloth sloth sloth sloth sloth sloth and sloth sloth
+
+#Duplicate
+sloth sloth sloth sloth sloth sloth sloth sloth sloth sloth 
+
+nap

--- a/slothvm.c
+++ b/slothvm.c
@@ -103,18 +103,18 @@ int execute(struct sloth_program* sbin){
       }
       case INP: {
         pc++;
+        printf(">");
 
         switch(P[pc]){
           case INT: {
             int x;
-            printf(">");
             scanf("%d", &x);
             spush(S, x);
             break;
           }
           case CHR: {
             char x;
-            scanf(">%c", &x);
+            scanf("%c", &x);
             spush(S, (int)x);
             break;
           }


### PR DESCRIPTION
I was messing around with some test programs (I'll push those later when they're ready) and I found a bug in the way input instructions work in character mode. It looks like you fixed the same problem with reading ints in 323b3df724294d9e02ea7b43291d392b756a5ce5, but characters got missed.